### PR TITLE
Fix host playhead playback status handling

### DIFF
--- a/Source/PluginManager.cpp
+++ b/Source/PluginManager.cpp
@@ -94,6 +94,7 @@ void PluginManager::getNextAudioBlock(const juce::AudioSourceChannelInfo& buffer
     pos.setPpqPosition(playbackSamplePosition
         * (currentBpm / 60.0)
         / currentSampleRate);
+    pos.setIsPlaying(true);
     
 	//// client side pointer check of hostPlayHead.positionInfo
 	//double bpm = hostPlayHead.positionInfo.getBpm() ? *hostPlayHead.positionInfo.getBpm() : 0.0;
@@ -547,9 +548,10 @@ void PluginManager::addMidiMessage(const juce::MidiMessage& message, const juce:
 
 void PluginManager::resetPlayback()
 {
-	playbackSamplePosition = 0;
-	// Also clear the taggedMidiBuffer
-	taggedMidiBuffer.clear();
+        playbackSamplePosition = 0;
+        hostPlayHead.positionInfo.setIsPlaying(false);
+        // Also clear the taggedMidiBuffer
+        taggedMidiBuffer.clear();
 	// And stop any currently playing notes
 	//for (const auto& [pluginId, pluginInstance] : pluginInstances)
 	//{


### PR DESCRIPTION
## Summary
- update playhead state in `PluginManager::getNextAudioBlock`
- mark playhead as not playing in `PluginManager::resetPlayback`

## Testing
- `clang++ -c Source/PluginManager.cpp -I." -I/usr/include/juce -std=c++17 -o /tmp/pm.o` *(fails: no JUCE headers)*

------
https://chatgpt.com/codex/tasks/task_e_6884ba25ce448325a5b436edfa7a0ab8