### PR TITLE
Fix sample rate handling

### DIFF
--- a/Source/PluginManager.cpp
+++ b/Source/PluginManager.cpp
@@ -67,11 +67,12 @@ PluginManager::~PluginManager()
 
 void PluginManager::prepareToPlay(int samplesPerBlockExpected, double sampleRate)
 {
+    currentSampleRate = sampleRate;
     for (auto& [pluginId, pluginInstance] : pluginInstances)
     {
         if (pluginInstance != nullptr)
         {
-			pluginInstance->prepareToPlay(sampleRate, samplesPerBlockExpected);
+                        pluginInstance->prepareToPlay(sampleRate, samplesPerBlockExpected);
 
         }
     }


### PR DESCRIPTION
## Summary
- ensure PluginManager stores the current sample rate in `prepareToPlay`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6884ba2f5d408325ab5880295dfd6608