### PR TITLE
Add MIDI overdub workflow and save functionality

### DIFF
--- a/Source/Conductor.cpp
+++ b/Source/Conductor.cpp
@@ -98,12 +98,12 @@ void Conductor::oscMessageReceived(const juce::OSCMessage& message)
 			{
 				oscAddInstrumentCommand(message);
 			}
-			else if (messageType == "get_recorded")
-			{
-				// activate get_recorded method
-				DBG("Received get_recorded command");
-				 midiManager.getRecorded();
-			}
+                        else if (messageType == "get_recorded")
+                        {
+                                // save the accumulated recording
+                                DBG("Received get_recorded command");
+                                midiManager.saveRecording();
+                        }
 			else if (messageType == "save_project")
 			{
 				saveAllData("projectData.dat", "projectPlugins.dat", "projectMeta.xml");

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -44,9 +44,9 @@ MainComponent::MainComponent()
 	addAndMakeVisible(updateButton);
 	updateButton.onClick = [this]() { conductor.syncOrchestraWithPluginManager(); }; // Use lambda for button click handling
 
-	// Initialize the "Get Recorded" button
-	addAndMakeVisible(getRecordedButton);
-	getRecordedButton.onClick = [this]() { midiManager.getRecorded(); }; // Use lambda for button click handling
+        // Initialize the "Overdub" button
+        addAndMakeVisible(overdubButton);
+        overdubButton.onClick = [this]() { midiManager.overdubPass(); }; // Use lambda for button click handling
 
 	// Initialize the "List Plugin Instances" button
 	addAndMakeVisible(listPluginInstancesButton);
@@ -79,9 +79,12 @@ MainComponent::MainComponent()
 	addAndMakeVisible(restoreButton);
 	restoreButton.onClick = [this]() { restoreProject(); }; // Use lambda for button click handling
 
-	// Add recording buttons
-	addAndMakeVisible(startRecordingButton);
-	startRecordingButton.onClick = [this]() { midiManager.startRecording(); }; // Use lambda for button click handling
+        // Add recording buttons
+        addAndMakeVisible(startRecordingButton);
+        startRecordingButton.onClick = [this]() { midiManager.startRecording(); }; // Use lambda for button click handling
+
+        addAndMakeVisible(saveRecordingButton);
+        saveRecordingButton.onClick = [this]() { midiManager.saveRecording(); }; // Use lambda for button click handling
 
 	// Add Project name label
 	addAndMakeVisible(projectNameLabel);
@@ -134,8 +137,8 @@ void MainComponent::resized()
 	int row1Y = windowHeight - margin - buttonHeight;
 	ScanButton.setBounds(margin, row1Y, buttonWidth, buttonHeight);
 	updateButton.setBounds(ScanButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
-	getRecordedButton.setBounds(updateButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
-	sendTestNoteButton.setBounds(getRecordedButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
+        overdubButton.setBounds(updateButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
+        sendTestNoteButton.setBounds(overdubButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
 	addInstrumentButton.setBounds(sendTestNoteButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
 
 	// Row 2
@@ -150,9 +153,10 @@ void MainComponent::resized()
 	int row3Y = row2Y - buttonHeight - spacingY;
 	saveButton.setBounds(margin, row3Y, buttonWidth, buttonHeight);
 	restoreButton.setBounds(saveButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
-	startRecordingButton.setBounds(restoreButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
-	addNewInstrumentButton.setBounds(startRecordingButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
-	moveToEndButton.setBounds(addNewInstrumentButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
+        startRecordingButton.setBounds(restoreButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
+        saveRecordingButton.setBounds(startRecordingButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
+        addNewInstrumentButton.setBounds(saveRecordingButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
+        moveToEndButton.setBounds(addNewInstrumentButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
 
 	// --- BPM Sync handler ---
 	bpmEditor.onTextChange = [this]() {

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -188,8 +188,9 @@ private:
     juce::ComboBox pluginBox;  // ComboBox to display plugins
 	juce::ComboBox midiInputList; // ComboBox to display MIDI inputs
 
-	juce::TextButton getRecordedButton{ "Get Recorded" }; // Button to trigger getRecorded
-	juce::TextButton startRecordingButton{ "Start Recording" }; // Button to trigger startRecording
+        juce::TextButton overdubButton{ "Overdub" }; // Button to commit the last pass
+        juce::TextButton startRecordingButton{ "Start Recording" }; // Button to zero the recording offset
+        juce::TextButton saveRecordingButton{ "Save Recording" }; // Button to save all recorded MIDI
 
 	juce::TextButton updateButton{ "Update" }; // Button to refresh the orchestra table
 	juce::TextButton listPluginInstancesButton{ "List Plugin Instances" }; // Button to list plugin instances

--- a/Source/MidiManager.h
+++ b/Source/MidiManager.h
@@ -24,13 +24,11 @@ public:
 	void handleIncomingMidiMessage(juce::MidiInput* source, const juce::MidiMessage& message) override;
 	void openMidiInput(juce::String midiInputName);
 	
-	void closeMidiInput();
-	void getRecorded();
-	void startRecording();
-	void sendTestNote();
-
-	// Declaration of the function to process recorded MIDI
-	void processRecordedMidi();
+        void closeMidiInput();
+        void startRecording();
+        void overdubPass();
+        void saveRecording();
+        void sendTestNote();
 
 	// Access to the MIDI buffer
 	juce::MidiBuffer& getMidiBuffer() { return incomingMidi; }
@@ -43,10 +41,11 @@ public:
 
 
 private:
-	// MIDI Input
-	std::unique_ptr<juce::MidiInput> midiInput; // MIDI Input object
-	juce::MidiBuffer recordBuffer; // MIDI Buffer to store recorded MIDI messages
-	juce::int64 recordStartTime; // Start time for recording MIDI messages
+        // MIDI Input
+        std::unique_ptr<juce::MidiInput> midiInput; // MIDI Input object
+        juce::MidiBuffer recordBuffer; // MIDI Buffer to store recorded MIDI messages
+        juce::MidiMessageSequence trackSequence; // Accumulated MIDI takes
+        juce::int64 recordStartTime; // Start time for recording MIDI messages
 
 	juce::CriticalSection& midiCriticalSection; // Critical section to protect the MIDI buffer
 	juce::MidiBuffer& incomingMidi; // MIDI Buffer to store incoming MIDI messages


### PR DESCRIPTION
## Summary
- add Overdub and Save Recording buttons for building layered MIDI takes
- track and merge new MIDI passes into a persistent sequence before writing to disk
- support OSC command for saving accumulated MIDI

## Testing
- `g++ -fsyntax-only Source/*.cpp` *(fails: JuceHeader.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5539c79c8325a1aaf4692aaf22ec