### PR TITLE
Add overdub undo, replay, and new recording features

### DIFF
--- a/Source/Conductor.cpp
+++ b/Source/Conductor.cpp
@@ -801,8 +801,8 @@ void OrchestraTableModel::selectRow(int row, const juce::ModifierKeys& modifiers
 	// This will allow row selection to be triggered.
 	table.selectRowsBasedOnModifierKeys(row, modifiers, true);
 
-	sendTags(row);
-	mainComponent->midiManager.startRecording();
+        sendTags(row);
+        mainComponent->midiManager.newRecording();
 
 	// Copy first tag in Tags to clipboard
 	//juce::SystemClipboard::copyTextToClipboard(orchestraData[row].tags.empty() ? "" : orchestraData[row].tags[0]);

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -44,17 +44,23 @@ MainComponent::MainComponent()
 	addAndMakeVisible(updateButton);
 	updateButton.onClick = [this]() { conductor.syncOrchestraWithPluginManager(); }; // Use lambda for button click handling
 
-        // Initialize the "Overdub" button
+        // Initialize the "Overdub" and related buttons
         addAndMakeVisible(overdubButton);
-        overdubButton.onClick = [this]() { midiManager.overdubPass(); }; // Use lambda for button click handling
+        overdubButton.onClick = [this]() { midiManager.overdubPass(); };
 
-	// Initialize the "List Plugin Instances" button
-	addAndMakeVisible(listPluginInstancesButton);
-	listPluginInstancesButton.onClick = [this]() { pluginManager.listPluginInstances(); }; // Use lambda for button click handling
+        addAndMakeVisible(undoOverdubButton);
+        undoOverdubButton.onClick = [this]() { midiManager.undoLastOverdub(); };
 
-	// Initialize the "Send Test Note" button
-	addAndMakeVisible(sendTestNoteButton);
-	sendTestNoteButton.onClick = [this]() { midiManager.sendTestNote(); }; // Use lambda for button click handling
+        addAndMakeVisible(replayButton);
+        replayButton.onClick = [this]() { midiManager.replay(); };
+
+        // Initialize the "List Plugin Instances" button
+        addAndMakeVisible(listPluginInstancesButton);
+        listPluginInstancesButton.onClick = [this]() { pluginManager.listPluginInstances(); };
+
+        // Initialize the "Send Test Note" button
+        addAndMakeVisible(sendTestNoteButton);
+        sendTestNoteButton.onClick = [this]() { midiManager.sendTestNote(); };
 
 	// Initialize the "Open Plugin" button
 	addAndMakeVisible(openPluginButton);
@@ -80,11 +86,11 @@ MainComponent::MainComponent()
 	restoreButton.onClick = [this]() { restoreProject(); }; // Use lambda for button click handling
 
         // Add recording buttons
-        addAndMakeVisible(startRecordingButton);
-        startRecordingButton.onClick = [this]() { midiManager.startRecording(); }; // Use lambda for button click handling
+        addAndMakeVisible(newRecordingButton);
+        newRecordingButton.onClick = [this]() { midiManager.newRecording(); };
 
         addAndMakeVisible(saveRecordingButton);
-        saveRecordingButton.onClick = [this]() { midiManager.saveRecording(); }; // Use lambda for button click handling
+        saveRecordingButton.onClick = [this]() { midiManager.saveRecording(); };
 
 	// Add Project name label
 	addAndMakeVisible(projectNameLabel);
@@ -135,11 +141,13 @@ void MainComponent::resized()
 
 	// Row 1 (bottom row)
 	int row1Y = windowHeight - margin - buttonHeight;
-	ScanButton.setBounds(margin, row1Y, buttonWidth, buttonHeight);
-	updateButton.setBounds(ScanButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
+        ScanButton.setBounds(margin, row1Y, buttonWidth, buttonHeight);
+        updateButton.setBounds(ScanButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
         overdubButton.setBounds(updateButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
-        sendTestNoteButton.setBounds(overdubButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
-	addInstrumentButton.setBounds(sendTestNoteButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
+        undoOverdubButton.setBounds(overdubButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
+        replayButton.setBounds(undoOverdubButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
+        sendTestNoteButton.setBounds(replayButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
+        addInstrumentButton.setBounds(sendTestNoteButton.getRight() + spacingX, row1Y, buttonWidth, buttonHeight);
 
 	// Row 2
 	int row2Y = row1Y - buttonHeight - spacingY;
@@ -153,8 +161,8 @@ void MainComponent::resized()
 	int row3Y = row2Y - buttonHeight - spacingY;
 	saveButton.setBounds(margin, row3Y, buttonWidth, buttonHeight);
 	restoreButton.setBounds(saveButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
-        startRecordingButton.setBounds(restoreButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
-        saveRecordingButton.setBounds(startRecordingButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
+        newRecordingButton.setBounds(restoreButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
+        saveRecordingButton.setBounds(newRecordingButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
         addNewInstrumentButton.setBounds(saveRecordingButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
         moveToEndButton.setBounds(addNewInstrumentButton.getRight() + spacingX, row3Y, buttonWidth, buttonHeight);
 

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -189,7 +189,9 @@ private:
 	juce::ComboBox midiInputList; // ComboBox to display MIDI inputs
 
         juce::TextButton overdubButton{ "Overdub" }; // Button to commit the last pass
-        juce::TextButton startRecordingButton{ "Start Recording" }; // Button to zero the recording offset
+        juce::TextButton undoOverdubButton{ "Undo Overdub" }; // Button to undo the last pass
+        juce::TextButton replayButton{ "Replay" }; // Button to replay without the last pass
+        juce::TextButton newRecordingButton{ "New Recording" }; // Button to zero the recording offset
         juce::TextButton saveRecordingButton{ "Save Recording" }; // Button to save all recorded MIDI
 
 	juce::TextButton updateButton{ "Update" }; // Button to refresh the orchestra table

--- a/Source/MidiManager.h
+++ b/Source/MidiManager.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include <vector>
 
 class MainComponent; // Forward declaration
 
@@ -25,8 +26,10 @@ public:
 	void openMidiInput(juce::String midiInputName);
 	
         void closeMidiInput();
-        void startRecording();
+        void newRecording();
         void overdubPass();
+        void undoLastOverdub();
+        void replay();
         void saveRecording();
         void sendTestNote();
 
@@ -46,6 +49,8 @@ private:
         juce::MidiBuffer recordBuffer; // MIDI Buffer to store recorded MIDI messages
         juce::MidiMessageSequence trackSequence; // Accumulated MIDI takes
         juce::int64 recordStartTime; // Start time for recording MIDI messages
+        struct OverdubPass { juce::MidiMessageSequence sequence; juce::int64 startTime; };
+        std::vector<OverdubPass> overdubPasses; // History of overdubs
 
 	juce::CriticalSection& midiCriticalSection; // Critical section to protect the MIDI buffer
 	juce::MidiBuffer& incomingMidi; // MIDI Buffer to store incoming MIDI messages


### PR DESCRIPTION
## Summary
- Support undoing the last overdub with internal pass history and buffer pruning.
- Add replay that discards the last overdub and resets recording timing.
- Rename start recording to new recording and add UI buttons for undo and replay.

## Testing
- No tests were run.

------
https://chatgpt.com/codex/tasks/task_e_68bd69b49ba48325ac3e62e714ce5a69