### PR TITLE
Add MIDI import/export using record buffer

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -99,14 +99,20 @@ MainComponent::MainComponent()
 	stopOverdubButton.onClick = [this]() { midiManager.stopOverdub(); updateOverdubUI(); };
 
 	// Initialize the "Strip Silence" button
-	addAndMakeVisible(stripLeadingSilenceButton);
-	stripLeadingSilenceButton.onClick = [this]() { midiManager.stripLeadingSilence(); updateOverdubUI(); };
+        addAndMakeVisible(stripLeadingSilenceButton);
+        stripLeadingSilenceButton.onClick = [this]() { midiManager.stripLeadingSilence(); updateOverdubUI(); };
 
-	// Initialize the "Undo Overdub" button
-	addAndMakeVisible(undoOverdubButton);
-	undoOverdubButton.onClick = [this]() { midiManager.undoLastOverdub(); updateOverdubUI(); };
+        // Initialize the "Undo Overdub" button
+        addAndMakeVisible(undoOverdubButton);
+        undoOverdubButton.onClick = [this]() { midiManager.undoLastOverdub(); updateOverdubUI(); };
 
-	updateOverdubUI();
+        addAndMakeVisible(importMidiButton);
+        importMidiButton.onClick = [this]() { midiManager.importMidiFileToRecordBuffer(); updateOverdubUI(); };
+
+        addAndMakeVisible(exportMidiButton);
+        exportMidiButton.onClick = [this]() { midiManager.exportRecordBufferToMidiFile(); };
+
+        updateOverdubUI();
 }
 
 void MainComponent::resized()
@@ -173,10 +179,12 @@ void MainComponent::resized()
 
 	// Row 4
 	int row4Y = row3Y - buttonHeight - spacingY;
-	startOverdubButton.setBounds(margin, row4Y, buttonWidth, buttonHeight);
-	stopOverdubButton.setBounds(startOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
-	stripLeadingSilenceButton.setBounds(stopOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
-	undoOverdubButton.setBounds(stripLeadingSilenceButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        startOverdubButton.setBounds(margin, row4Y, buttonWidth, buttonHeight);
+        stopOverdubButton.setBounds(startOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        stripLeadingSilenceButton.setBounds(stopOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        undoOverdubButton.setBounds(stripLeadingSilenceButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        importMidiButton.setBounds(undoOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        exportMidiButton.setBounds(importMidiButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
 
 
 

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -225,11 +225,13 @@ private:
 	juce::Label audioStreamingPortLabel{ "Audio Streaming Port", "Audio Streaming Port" }; // Label for the audio streaming port
 	juce::TextEditor audioStreamingPortEditor; // Text editor for the audio streaming port
 
-	// Buttons for overdub control
+        // Buttons for overdub control
     juce::TextButton startOverdubButton { "Start Overdub" };
     juce::TextButton stopOverdubButton { "Stop Overdub" };
     juce::TextButton stripLeadingSilenceButton { "Strip Silence" };
     juce::TextButton undoOverdubButton { "Undo Overdub" };
+        juce::TextButton importMidiButton { "Import MIDI" };
+        juce::TextButton exportMidiButton { "Export MIDI" };
 
 	PluginManager pluginManager { this, midiCriticalSection, midiBuffer }; // Create an instance of the PluginManager class
 	Conductor conductor{ pluginManager, midiManager, this }; // Create an instance of the Conductor class


### PR DESCRIPTION
## Summary
- add UI controls to trigger MIDI import and export for the recorded buffer
- implement MIDI export with channel-aware track names derived from orchestra tags
- support importing MIDI files by matching track names back to channels and republishing events

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d576f18b0c832594cce7449a3b7beb