### PR TITLE
Handle plugin channel creation during MIDI import

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -99,14 +99,20 @@ MainComponent::MainComponent()
 	stopOverdubButton.onClick = [this]() { midiManager.stopOverdub(); updateOverdubUI(); };
 
 	// Initialize the "Strip Silence" button
-	addAndMakeVisible(stripLeadingSilenceButton);
-	stripLeadingSilenceButton.onClick = [this]() { midiManager.stripLeadingSilence(); updateOverdubUI(); };
+        addAndMakeVisible(stripLeadingSilenceButton);
+        stripLeadingSilenceButton.onClick = [this]() { midiManager.stripLeadingSilence(); updateOverdubUI(); };
 
-	// Initialize the "Undo Overdub" button
-	addAndMakeVisible(undoOverdubButton);
-	undoOverdubButton.onClick = [this]() { midiManager.undoLastOverdub(); updateOverdubUI(); };
+        // Initialize the "Undo Overdub" button
+        addAndMakeVisible(undoOverdubButton);
+        undoOverdubButton.onClick = [this]() { midiManager.undoLastOverdub(); updateOverdubUI(); };
 
-	updateOverdubUI();
+        addAndMakeVisible(importMidiButton);
+        importMidiButton.onClick = [this]() { midiManager.importMidiFileToRecordBuffer(); updateOverdubUI(); };
+
+        addAndMakeVisible(exportMidiButton);
+        exportMidiButton.onClick = [this]() { midiManager.exportRecordBufferToMidiFile(); };
+
+        updateOverdubUI();
 }
 
 void MainComponent::resized()
@@ -173,10 +179,12 @@ void MainComponent::resized()
 
 	// Row 4
 	int row4Y = row3Y - buttonHeight - spacingY;
-	startOverdubButton.setBounds(margin, row4Y, buttonWidth, buttonHeight);
-	stopOverdubButton.setBounds(startOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
-	stripLeadingSilenceButton.setBounds(stopOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
-	undoOverdubButton.setBounds(stripLeadingSilenceButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        startOverdubButton.setBounds(margin, row4Y, buttonWidth, buttonHeight);
+        stopOverdubButton.setBounds(startOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        stripLeadingSilenceButton.setBounds(stopOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        undoOverdubButton.setBounds(stripLeadingSilenceButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        importMidiButton.setBounds(undoOverdubButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
+        exportMidiButton.setBounds(importMidiButton.getRight() + spacingX, row4Y, buttonWidth, buttonHeight);
 
 
 

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -225,11 +225,13 @@ private:
 	juce::Label audioStreamingPortLabel{ "Audio Streaming Port", "Audio Streaming Port" }; // Label for the audio streaming port
 	juce::TextEditor audioStreamingPortEditor; // Text editor for the audio streaming port
 
-	// Buttons for overdub control
+        // Buttons for overdub control
     juce::TextButton startOverdubButton { "Start Overdub" };
     juce::TextButton stopOverdubButton { "Stop Overdub" };
     juce::TextButton stripLeadingSilenceButton { "Strip Silence" };
     juce::TextButton undoOverdubButton { "Undo Overdub" };
+        juce::TextButton importMidiButton { "Import MIDI" };
+        juce::TextButton exportMidiButton { "Export MIDI" };
 
 	PluginManager pluginManager { this, midiCriticalSection, midiBuffer }; // Create an instance of the PluginManager class
 	Conductor conductor{ pluginManager, midiManager, this }; // Create an instance of the Conductor class

--- a/Source/MidiManager.cpp
+++ b/Source/MidiManager.cpp
@@ -13,6 +13,9 @@
 #include "PluginManager.h"
 
 #include <limits>
+#include <map>
+#include <utility>
+#include <algorithm>
 
 
 void MidiManager::handleIncomingMidiMessage(juce::MidiInput* source, const juce::MidiMessage& message)
@@ -45,6 +48,173 @@ void MidiManager::handleIncomingMidiMessage(juce::MidiInput* source, const juce:
 		// Stamp the MIDI message with high-resolution ticks directly
 		recordBuffer.addEvent(messageWithChannel, static_cast<int>(currentTimeTicks));
 	}
+}
+
+std::map<int, juce::String> MidiManager::buildChannelTagMap(const juce::String& pluginId) const
+{
+        std::map<int, juce::String> channelTags;
+
+        if (mainComponent == nullptr)
+                return channelTags;
+
+        const auto& orchestra = mainComponent->getConductor().orchestra;
+        for (const auto& instrument : orchestra)
+        {
+                if (pluginId.isNotEmpty() && instrument.pluginInstanceId != pluginId)
+                        continue;
+
+                auto tagString = serialiseTags(instrument.tags);
+                if (tagString.isEmpty())
+                        tagString = instrument.instrumentName;
+
+                channelTags[instrument.midiChannel] = tagString;
+        }
+
+        return channelTags;
+}
+
+juce::String MidiManager::serialiseTags(const std::vector<juce::String>& tags)
+{
+        juce::StringArray tagArray;
+        for (const auto& tag : tags)
+        {
+                auto trimmed = tag.trim();
+                if (trimmed.isNotEmpty())
+                        tagArray.add(trimmed);
+        }
+
+        return tagArray.joinIntoString(", ");
+}
+
+juce::String MidiManager::extractTrackName(const juce::MidiMessageSequence& sequence)
+{
+        for (int i = 0; i < sequence.getNumEvents(); ++i)
+        {
+                const auto* holder = sequence.getEventPointer(i);
+                if (holder == nullptr)
+                        continue;
+
+                const auto& message = holder->message;
+                if (message.isTextMetaEvent() && message.getMetaEventType() == juce::MidiMessage::metaEventTrackName)
+                        return message.getTextFromTextMetaEvent();
+        }
+
+        return {};
+}
+
+std::map<int, MidiManager::ChannelTrackInfo> MidiManager::buildChannelSequences(const juce::MidiBuffer& bufferCopy) const
+{
+        std::map<int, ChannelTrackInfo> channelSequences;
+
+        if (bufferCopy.getNumEvents() == 0)
+                return channelSequences;
+
+        struct EventData
+        {
+                juce::MidiMessage message;
+                int channel{ 0 };
+                juce::int64 timestamp{ 0 };
+        };
+
+        std::vector<EventData> events;
+        events.reserve(static_cast<size_t>(bufferCopy.getNumEvents()));
+
+        juce::int64 earliestTimestamp = std::numeric_limits<juce::int64>::max();
+
+        juce::MidiBuffer::Iterator iterator(bufferCopy);
+        juce::MidiMessage eventMessage;
+        int samplePosition = 0;
+
+        while (iterator.getNextEvent(eventMessage, samplePosition))
+        {
+                EventData data;
+                data.message = eventMessage;
+                data.channel = juce::jlimit(1, 16, data.message.getChannel());
+                data.timestamp = getTimestampFromEvent(data.message, samplePosition);
+
+                if (data.timestamp < earliestTimestamp)
+                        earliestTimestamp = data.timestamp;
+
+                events.push_back(std::move(data));
+        }
+
+        if (earliestTimestamp == std::numeric_limits<juce::int64>::max())
+                earliestTimestamp = 0;
+
+        auto ticksPerSecond = juce::Time::getHighResolutionTicksPerSecond();
+        double ticksPerQuarterNote = 960.0;
+        double bpm = mainComponent != nullptr ? mainComponent->getBpm() : 120.0;
+        if (bpm <= 0.0)
+                bpm = 120.0;
+
+        double tickConversionFactor = ticksPerSecond > 0
+                ? (ticksPerQuarterNote * bpm) / (static_cast<double>(ticksPerSecond) * 60.0)
+                : 1.0;
+
+        for (auto& event : events)
+        {
+                auto timeDiff = event.timestamp - earliestTimestamp;
+                if (timeDiff < 0)
+                        timeDiff = 0;
+
+                double timeInTicks = static_cast<double>(timeDiff) * tickConversionFactor;
+                if (timeInTicks < 0.0)
+                        timeInTicks = 0.0;
+
+                event.message.setTimeStamp(timeInTicks);
+
+                auto& channelInfo = channelSequences[event.channel];
+                channelInfo.sequence.addEvent(event.message);
+        }
+
+        return channelSequences;
+}
+
+void MidiManager::writeMidiFile(const juce::File& file, const std::map<int, ChannelTrackInfo>& channelSequences) const
+{
+        if (channelSequences.empty())
+                return;
+
+        juce::MidiFile midiFile;
+        midiFile.setTicksPerQuarterNote(960);
+
+        for (const auto& entry : channelSequences)
+        {
+                auto sequence = entry.second.sequence;
+                if (sequence.getNumEvents() == 0)
+                        continue;
+
+                if (entry.second.trackName.isNotEmpty())
+                {
+                        auto trackNameMessage = juce::MidiMessage::textMetaEvent(juce::MidiMessage::metaEventTrackName, entry.second.trackName);
+                        trackNameMessage.setTimeStamp(0.0);
+                        sequence.addEvent(trackNameMessage);
+                }
+
+                sequence.updateMatchedPairs();
+                midiFile.addTrack(sequence);
+        }
+
+        if (midiFile.getNumTracks() == 0)
+                return;
+
+        juce::File parentDir = file.getParentDirectory();
+        if (!parentDir.exists())
+                parentDir.createDirectory();
+
+        if (file.existsAsFile())
+                file.deleteFile();
+
+        juce::FileOutputStream stream(file);
+        if (!stream.openedOk())
+        {
+                DBG("Failed to open file for writing MIDI data: " + file.getFullPathName());
+                return;
+        }
+
+        midiFile.writeTo(stream);
+        stream.flush();
+        DBG("MIDI File Saved: " + file.getFullPathName());
 }
 
 void MidiManager::openMidiInput(juce::String midiInputName)
@@ -298,21 +468,40 @@ void MidiManager::processRecordedMidi()
 	}
 
 	// Finally, write out to your MIDI file
-	saveToMidiFile(recordedMidi);
+        saveToMidiFile(recordedMidi);
 }
 
 
 
 void MidiManager::saveToMidiFile(juce::MidiMessageSequence& recordedMIDI)
 {
-	juce::MidiFile midiFile;  // Create a MidiFile object
-	midiFile.setTicksPerQuarterNote(960);  // Set the ticks per quarter note (can adjust based on your needs)
+        juce::MidiFile midiFile;  // Create a MidiFile object
+        midiFile.setTicksPerQuarterNote(960);  // Set the ticks per quarter note (can adjust based on your needs)
 
-	// Add the recorded MIDI events to the MidiFile object
-	midiFile.addTrack(recordedMIDI);
+        // Add the recorded MIDI events to the MidiFile object
+        juce::String trackName;
+        if (mainComponent != nullptr)
+        {
+                auto channel = mainComponent->getOrchestraTableModel().getSelectedMidiChannel();
+                auto pluginId = mainComponent->getOrchestraTableModel().getSelectedPluginId();
+                auto channelTags = buildChannelTagMap(pluginId);
+                auto it = channelTags.find(channel);
+                if (it != channelTags.end())
+                        trackName = it->second;
+        }
 
-	// Create a file to save the MIDI data
-	juce::File midiFileToSave = juce::File::getSpecialLocation(juce::File::userDocumentsDirectory).getChildFile("recordedMIDI.mid");
+        if (trackName.isNotEmpty() && extractTrackName(recordedMIDI).isEmpty())
+        {
+                auto trackNameMessage = juce::MidiMessage::textMetaEvent(juce::MidiMessage::metaEventTrackName, trackName);
+                trackNameMessage.setTimeStamp(0.0);
+                recordedMIDI.addEvent(trackNameMessage);
+        }
+
+        recordedMIDI.updateMatchedPairs();
+        midiFile.addTrack(recordedMIDI);
+
+        // Create a file to save the MIDI data
+        juce::File midiFileToSave = juce::File::getSpecialLocation(juce::File::userDocumentsDirectory).getChildFile("recordedMIDI.mid");
 
 	// If you want to ensure the file is fresh, delete it if it exists before proceeding
 	if (midiFileToSave.existsAsFile())
@@ -325,10 +514,287 @@ void MidiManager::saveToMidiFile(juce::MidiMessageSequence& recordedMIDI)
 	// Save the MIDI data to the file
 	midiFile.writeTo(stream);
 
-	stream.flush();
+        stream.flush();
 
-	DBG("MIDI File Saved: " + midiFileToSave.getFullPathName());
+        DBG("MIDI File Saved: " + midiFileToSave.getFullPathName());
 
+}
+
+void MidiManager::exportRecordBufferToMidiFile()
+{
+        juce::MidiBuffer bufferCopy;
+        {
+                const juce::ScopedLock sl(midiCriticalSection);
+                if (recordBuffer.getNumEvents() == 0)
+                {
+                        DBG("No MIDI events to export.");
+                        return;
+                }
+
+                bufferCopy = recordBuffer;
+        }
+
+        juce::FileChooser fileChooser("Export MIDI File", juce::File::getSpecialLocation(juce::File::userDocumentsDirectory), "*.mid");
+        if (!fileChooser.browseForFileToSave(true))
+                return;
+
+        auto targetFile = fileChooser.getResult();
+
+        auto channelSequences = buildChannelSequences(bufferCopy);
+
+        juce::String pluginId;
+        if (mainComponent != nullptr)
+                pluginId = mainComponent->getOrchestraTableModel().getSelectedPluginId();
+
+        auto channelTags = buildChannelTagMap(pluginId);
+
+        if (pluginId.isNotEmpty())
+        {
+                for (auto it = channelSequences.begin(); it != channelSequences.end();)
+                {
+                        if (channelTags.find(it->first) == channelTags.end())
+                                it = channelSequences.erase(it);
+                        else
+                                ++it;
+                }
+        }
+
+        for (auto& entry : channelSequences)
+        {
+                auto it = channelTags.find(entry.first);
+                if (it != channelTags.end() && it->second.isNotEmpty())
+                        entry.second.trackName = it->second;
+                else if (pluginId.isNotEmpty())
+                        entry.second.trackName = pluginId + " Ch " + juce::String(entry.first);
+                else
+                        entry.second.trackName = "Channel " + juce::String(entry.first);
+        }
+
+        writeMidiFile(targetFile, channelSequences);
+}
+
+void MidiManager::importMidiFileToRecordBuffer()
+{
+        juce::FileChooser fileChooser("Import MIDI File", juce::File::getSpecialLocation(juce::File::userDocumentsDirectory), "*.mid");
+        if (!fileChooser.browseForFileToOpen())
+                return;
+
+        auto midiFileToImport = fileChooser.getResult();
+        juce::FileInputStream inputStream(midiFileToImport);
+
+        if (!inputStream.openedOk())
+        {
+                DBG("Failed to open MIDI file: " + midiFileToImport.getFullPathName());
+                return;
+        }
+
+        juce::MidiFile midiFile;
+        if (!midiFile.readFrom(inputStream))
+        {
+                DBG("Failed to read MIDI data from file: " + midiFileToImport.getFullPathName());
+                return;
+        }
+
+        midiFile.convertTimestampTicksToSeconds();
+
+        juce::MidiBuffer newBuffer;
+        auto ticksPerSecond = juce::Time::getHighResolutionTicksPerSecond();
+
+        juce::String pluginId;
+        if (mainComponent != nullptr)
+                pluginId = mainComponent->getOrchestraTableModel().getSelectedPluginId();
+
+        auto channelTags = buildChannelTagMap(pluginId);
+        std::map<juce::String, int> tagToChannel;
+        auto rebuildTagToChannel = [&]()
+        {
+                tagToChannel.clear();
+                for (const auto& entry : channelTags)
+                {
+                        auto name = entry.second.trim();
+                        if (name.isNotEmpty())
+                                tagToChannel[name] = entry.first;
+                }
+        };
+        rebuildTagToChannel();
+
+        for (int trackIndex = 0; trackIndex < midiFile.getNumTracks(); ++trackIndex)
+        {
+                auto* track = midiFile.getTrack(trackIndex);
+                if (track == nullptr)
+                        continue;
+
+                auto trackName = extractTrackName(*track).trim();
+                int channelForTrack = 0;
+                auto channelIt = tagToChannel.find(trackName);
+                if (channelIt != tagToChannel.end())
+                        channelForTrack = channelIt->second;
+
+                if (channelForTrack == 0)
+                        channelForTrack = extractChannelFromTrack(*track);
+
+                if (pluginId.isNotEmpty() && channelForTrack == 0)
+                        continue;
+
+                if (pluginId.isNotEmpty() && channelForTrack > 0)
+                {
+                        if (ensurePluginChannelEntry(pluginId, channelForTrack, trackName))
+                        {
+                                channelTags = buildChannelTagMap(pluginId);
+                                rebuildTagToChannel();
+                                auto refreshed = tagToChannel.find(trackName);
+                                if (refreshed != tagToChannel.end())
+                                        channelForTrack = refreshed->second;
+                        }
+                }
+
+                if (channelForTrack == 0)
+                        channelForTrack = extractChannelFromTrack(*track);
+
+                for (int eventIndex = 0; eventIndex < track->getNumEvents(); ++eventIndex)
+                {
+                        const auto* holder = track->getEventPointer(eventIndex);
+                        if (holder == nullptr)
+                                continue;
+
+                        const auto& message = holder->message;
+                        if (message.isMetaEvent())
+                                continue;
+
+                        juce::MidiMessage messageCopy = message;
+                        if (channelForTrack > 0)
+                                messageCopy.setChannel(channelForTrack);
+
+                        double timeInSeconds = messageCopy.getTimeStamp();
+                        juce::int64 timestamp = ticksPerSecond > 0
+                                ? static_cast<juce::int64>(timeInSeconds * static_cast<double>(ticksPerSecond))
+                                : static_cast<juce::int64>(timeInSeconds * 1000.0);
+
+                        if (timestamp < 0)
+                                timestamp = 0;
+
+                        messageCopy.setTimeStamp(static_cast<double>(timestamp));
+                        newBuffer.addEvent(messageCopy, static_cast<int>(timestamp));
+                }
+        }
+
+        if (newBuffer.getNumEvents() == 0)
+        {
+                DBG("No MIDI events were imported from file: " + midiFileToImport.getFullPathName());
+                return;
+        }
+
+        {
+                const juce::ScopedLock sl(midiCriticalSection);
+                recordBuffer = newBuffer;
+                overdubHistory.clear();
+                isOverdubbing = false;
+                recordStartTime = juce::Time::getHighResolutionTicks();
+        }
+
+        republishRecordedEvents(newBuffer);
+}
+
+int MidiManager::extractChannelFromTrack(const juce::MidiMessageSequence& track)
+{
+        for (int eventIndex = 0; eventIndex < track.getNumEvents(); ++eventIndex)
+        {
+                const auto* holder = track.getEventPointer(eventIndex);
+                if (holder == nullptr)
+                        continue;
+
+                const auto& message = holder->message;
+                if (message.isMetaEvent())
+                        continue;
+
+                auto channel = message.getChannel();
+                if (channel > 0)
+                        return juce::jlimit(1, 16, channel);
+        }
+
+        return 0;
+}
+
+bool MidiManager::ensurePluginChannelEntry(const juce::String& pluginId, int channel, const juce::String& trackName)
+{
+        if (mainComponent == nullptr || pluginId.isEmpty() || channel <= 0)
+                return false;
+
+        auto trimmedName = trackName.trim();
+        auto& conductor = mainComponent->getConductor();
+        auto& orchestra = conductor.orchestra;
+
+        auto existingIt = std::find_if(orchestra.begin(), orchestra.end(), [&](const InstrumentInfo& instrument)
+        {
+                return instrument.pluginInstanceId == pluginId && instrument.midiChannel == channel;
+        });
+
+        if (existingIt != orchestra.end())
+        {
+                if (trimmedName.isEmpty())
+                        return false;
+
+                auto& instrument = *existingIt;
+                auto& tags = instrument.tags;
+                bool matchesExisting = tags.size() == 1 && tags.front().compareIgnoreCase(trimmedName) == 0;
+
+                if (!matchesExisting)
+                {
+                        tags.clear();
+                        tags.push_back(trimmedName);
+                        instrument.instrumentName = trimmedName;
+                        mainComponent->getOrchestraTableModel().table.updateContent();
+                        return true;
+                }
+
+                return false;
+        }
+
+        InstrumentInfo newInstrument;
+
+        auto templateIt = std::find_if(orchestra.begin(), orchestra.end(), [&](const InstrumentInfo& instrument)
+        {
+                return instrument.pluginInstanceId == pluginId;
+        });
+
+        if (templateIt != orchestra.end())
+        {
+                newInstrument = *templateIt;
+        }
+        else if (!orchestra.empty())
+        {
+                newInstrument = orchestra.front();
+        }
+        else
+        {
+                newInstrument.instrumentName = trimmedName.isNotEmpty() ? trimmedName : pluginId + " Ch " + juce::String(channel);
+                newInstrument.pluginName = pluginId;
+                newInstrument.pluginInstanceId = pluginId;
+                newInstrument.tags.clear();
+        }
+
+        newInstrument.pluginInstanceId = pluginId;
+        newInstrument.midiChannel = channel;
+
+        if (trimmedName.isNotEmpty())
+        {
+                newInstrument.instrumentName = trimmedName;
+                newInstrument.tags.clear();
+                newInstrument.tags.push_back(trimmedName);
+        }
+        else
+        {
+                auto defaultName = pluginId + " Ch " + juce::String(channel);
+                newInstrument.instrumentName = defaultName;
+                if (newInstrument.tags.empty())
+                        newInstrument.tags.push_back(defaultName);
+        }
+
+        orchestra.push_back(newInstrument);
+        conductor.syncOrchestraWithPluginManager();
+        mainComponent->getOrchestraTableModel().table.updateContent();
+
+        return true;
 }
 
 bool MidiManager::canUndoOverdub() const

--- a/Source/MidiManager.h
+++ b/Source/MidiManager.h
@@ -12,6 +12,7 @@
 
 #include <JuceHeader.h>
 #include <vector>
+#include <map>
 
 class MainComponent; // Forward declaration
 
@@ -31,14 +32,17 @@ public:
 	void stripLeadingSilence();
 	void undoLastOverdub();
 	void getRecorded();
-	void startRecording();
-	void sendTestNote();
+        void startRecording();
+        void sendTestNote();
 
-	bool canUndoOverdub() const;
-	bool hasRecordedEvents() const;
+        void exportRecordBufferToMidiFile();
+        void importMidiFileToRecordBuffer();
 
-	// Declaration of the function to process recorded MIDI
-	void processRecordedMidi();
+        bool canUndoOverdub() const;
+        bool hasRecordedEvents() const;
+
+        // Declaration of the function to process recorded MIDI
+        void processRecordedMidi();
 	bool isOverdubbing = false;
 
 	// Access to the MIDI buffer
@@ -48,28 +52,42 @@ public:
 	juce::CriticalSection& getCriticalSection() { return midiCriticalSection; }
 
 	// Save to MIDI file
-	void saveToMidiFile(juce::MidiMessageSequence& recordedMIDI);
+        void saveToMidiFile(juce::MidiMessageSequence& recordedMIDI);
 
-	std::unique_ptr<juce::Thread> playbackThread;
-	std::atomic<bool> playbackThreadShouldRun{ false };
+        std::unique_ptr<juce::Thread> playbackThread;
+        std::atomic<bool> playbackThreadShouldRun{ false };
 
 
 
 private:
-	// MIDI Input
-	std::unique_ptr<juce::MidiInput> midiInput; // MIDI Input object
-	juce::MidiBuffer recordBuffer; // MIDI Buffer to store recorded MIDI messages
-	juce::int64 recordStartTime; // Start time for recording MIDI messages
+        struct ChannelTrackInfo
+        {
+                juce::MidiMessageSequence sequence;
+                juce::String trackName;
+        };
+
+        // MIDI Input
+        std::unique_ptr<juce::MidiInput> midiInput; // MIDI Input object
+        juce::MidiBuffer recordBuffer; // MIDI Buffer to store recorded MIDI messages
+        juce::int64 recordStartTime; // Start time for recording MIDI messages
 
 	juce::CriticalSection& midiCriticalSection; // Critical section to protect the MIDI buffer
 	juce::MidiBuffer& incomingMidi; // MIDI Buffer to store incoming MIDI messages
 
 	MainComponent* mainComponent; // Pointer to the MainComponent
 
-	std::vector<juce::MidiBuffer> overdubHistory;
+        std::vector<juce::MidiBuffer> overdubHistory;
 
-	static juce::int64 getTimestampFromEvent(const juce::MidiMessage& message, int samplePosition);
-	void republishRecordedEvents(const juce::MidiBuffer& bufferCopy);
+        static juce::int64 getTimestampFromEvent(const juce::MidiMessage& message, int samplePosition);
+        void republishRecordedEvents(const juce::MidiBuffer& bufferCopy);
 
-	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MidiManager)
+        std::map<int, juce::String> buildChannelTagMap(const juce::String& pluginId) const;
+        static juce::String serialiseTags(const std::vector<juce::String>& tags);
+        static juce::String extractTrackName(const juce::MidiMessageSequence& sequence);
+        std::map<int, ChannelTrackInfo> buildChannelSequences(const juce::MidiBuffer& bufferCopy) const;
+        void writeMidiFile(const juce::File& file, const std::map<int, ChannelTrackInfo>& channelSequences) const;
+        static int extractChannelFromTrack(const juce::MidiMessageSequence& sequence);
+        bool ensurePluginChannelEntry(const juce::String& pluginId, int channel, const juce::String& trackName);
+
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MidiManager)
 };


### PR DESCRIPTION
## Summary
- restrict MIDI export tracks to channels belonging to the selected plugin and preserve their tag names
- ensure MIDI import uses the first selected plugin row, creating or updating channel entries for that plugin before loading events

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d576f18b0c832594cce7449a3b7beb