### PR TITLE
Use AudioAppComponent device manager

### DIFF
--- a/Source/PluginManager.cpp
+++ b/Source/PluginManager.cpp
@@ -56,7 +56,6 @@ PluginManager::PluginManager(MainComponent* mainComponent, juce::CriticalSection
 	: mainComponent(mainComponent), midiCriticalSection(criticalSection), incomingMidi(midiBuffer)
 {
     formatManager.addFormat(new juce::VST3PluginFormat());  // Adds only VST3 format to the format manager
-    deviceManager.initialise(4, 32, nullptr, true); // Initialize with 4 input and 8 output channels.
     setAudioChannels(4, 32); // Set input and output channels to 4 and 8, respectively.
 
 }
@@ -109,7 +108,7 @@ void PluginManager::getNextAudioBlock(const juce::AudioSourceChannelInfo& buffer
     const juce::ScopedLock pluginLock(pluginInstanceLock);
 
     // Guard against missing audio device
-    if (auto* audioDevice = deviceManager.getCurrentAudioDevice(); audioDevice != nullptr)
+    if (auto* audioDevice = getAudioDeviceManager().getCurrentAudioDevice(); audioDevice != nullptr)
     {
         double sampleRate = audioDevice->getCurrentSampleRate();
 
@@ -278,8 +277,9 @@ void PluginManager::instantiatePlugin(juce::PluginDescription* desc, const juce:
 {
     juce::String errorMessage;
 
-    auto sampleRate = deviceManager.getAudioDeviceSetup().sampleRate;
-    auto blockSize = deviceManager.getAudioDeviceSetup().bufferSize;
+    auto setup = getAudioDeviceManager().getAudioDeviceSetup();
+    auto sampleRate = setup.sampleRate;
+    auto blockSize = setup.bufferSize;
 
     std::unique_ptr<juce::AudioPluginInstance> instance = formatManager.createPluginInstance(
         *desc, sampleRate, blockSize, errorMessage);

--- a/Source/PluginManager.h
+++ b/Source/PluginManager.h
@@ -113,9 +113,6 @@ public:
     void saveAllPluginStates(const juce::String& dataFilePath, std::vector<juce::String> instances = {});
     void restoreAllPluginStates(const juce::String& dataFilePath);
 
-	// Getter for deviceManager
-	juce::AudioDeviceManager& getDeviceManager() { return deviceManager; }
-
     void renamePluginInstance(const juce::String& oldId, const juce::String& newId);
     std::function<void(const juce::AudioBuffer<float>&)> audioTapCallback;
 
@@ -128,8 +125,6 @@ private:
     // A vector to hold tagged MIDI messages
     std::vector<MyMidiMessage> taggedMidiBuffer;
     std::map<juce::String, std::map<int, std::vector<juce::String>>> channelTagsMap;
-
-    juce::AudioDeviceManager deviceManager;
     juce::AudioPluginFormatManager formatManager;
 
     juce::CriticalSection& midiCriticalSection;


### PR DESCRIPTION
## Summary
- remove PluginManager's private AudioDeviceManager and rely on the base AudioAppComponent manager
- update audio block processing and plugin instantiation to query the shared device manager

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e15497764883258d3cca4c28112e17