### PR TITLE
Add audio driver selection dropdown and enable ASIO support

### DIFF
--- a/OSCDawServer.jucer
+++ b/OSCDawServer.jucer
@@ -45,7 +45,7 @@
     <MODULE id="juce_osc" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
   </MODULES>
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_PLUGINHOST_VST3="1" JUCE_USE_WINRT_MIDI="1"
-               JUCE_WASAPI="1"/>
+               JUCE_WASAPI="1" JUCE_ASIO="1"/>
   <EXPORTFORMATS>
     <VS2022 targetFolder="Builds/VisualStudio2022" smallIcon="ZCiG4M" bigIcon="ZCiG4M"
             extraDefs="JUCE_USE_WINRT_MIDI=0">

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -154,7 +154,8 @@ public:
 
 	void scanForPlugins();
 	void initPlugins();
-	void initMidiInputs();
+        void initMidiInputs();
+        void initAudioDrivers();
 	void initOrchestraTable();
 	void saveProject(const std::vector<InstrumentInfo>& selectedInstruments = {});
 	void restoreProject(bool append = false);
@@ -187,8 +188,10 @@ private:
     juce::File pluginFolder; // Use a juce::File object instead of a pointer
 
 	// Add ComboBoxes for plugin selection and MIDI input selection
-    juce::ComboBox pluginBox;  // ComboBox to display plugins
-	juce::ComboBox midiInputList; // ComboBox to display MIDI inputs
+        juce::ComboBox pluginBox;  // ComboBox to display plugins
+        juce::ComboBox midiInputList; // ComboBox to display MIDI inputs
+        juce::Label audioDriverLabel{ "Audio Driver", "Audio Driver" };
+        juce::ComboBox audioDriverList;
 
 	juce::TextButton getRecordedButton{ "Get and Reset" }; // Button to trigger 
 	juce::TextButton updateButton{ "Update" }; // Button to refresh the orchestra table


### PR DESCRIPTION
## Summary
- add an audio driver selection combo box to MainComponent so users can choose the JUCE device type (including ASIO)
- adjust the layout to accommodate the new selector and initialize it with the current device
- enable the JUCE_ASIO option in the project configuration

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e174ca7ca88325a613c46aff57332a